### PR TITLE
Add a bunch of missing keywords

### DIFF
--- a/grammars/pl sql (oracle).cson
+++ b/grammars/pl sql (oracle).cson
@@ -155,7 +155,7 @@ patterns: [
    name: "keyword.other.end.oracle"
   }
   {
-    match: "(?i)\\b(end|then|deterministic|exception|when|exists|others|subtype|constant|range|declare|begin|in|out|to|is|as|exit|raise|cursor|record|open|fetch|into|close|%type|%rowtype|execute|comment|column|synonym|sequence|index\\s+by|start\\s+with|increment\\s+by|cache|pragma|grant|start|alter|database|datafile|autoextend|trigger|after|before|each|row|default|\\.(extend|count|first|last|next|nextval|currval|reverse)|sqlerror|oserror)\\b"
+    match: "(?i)\\b(end|then|deterministic|exception|when|exists|others|subtype|constant|range|declare|begin|in|out|to|is|as|exit|raise|cursor|record|open|fetch|into|close|%type|%rowtype|execute|comment|column|synonym|sequence|index\\s+by|start\\s+with|increment\\s+by|cache|pragma|grant|start|alter|database|datafile|autoextend|trigger|after|before|each|row|default|\\.(extend|count|first|last|next|nextval|currval|reverse)|sqlerror|oserror|connect)\\b"
     name: "keyword.other.oracle"
   }
   {

--- a/grammars/pl sql (oracle).cson
+++ b/grammars/pl sql (oracle).cson
@@ -155,7 +155,7 @@ patterns: [
    name: "keyword.other.end.oracle"
   }
   {
-    match: "(?i)\\b(end|then|deterministic|exception|when|exists|others|subtype|constant|range|declare|begin|in|out|to|is|as|exit|raise|cursor|record|open|fetch|into|close|%type|%rowtype|execute|comment|column|synonym|sequence|index\\s+by|start\\s+with|increment\\s+by|cache|pragma|grant|start|alter|database|datafile|autoextend|trigger|after|before|each|row|default|\\.(extend|count|first|last|next|nextval|currval|reverse))\\b"
+    match: "(?i)\\b(end|then|deterministic|exception|when|exists|others|subtype|constant|range|declare|begin|in|out|to|is|as|exit|raise|cursor|record|open|fetch|into|close|%type|%rowtype|execute|comment|column|synonym|sequence|index\\s+by|start\\s+with|increment\\s+by|cache|pragma|grant|start|alter|database|datafile|autoextend|trigger|after|before|each|row|default|\\.(extend|count|first|last|next|nextval|currval|reverse)|sqlerror|oserror)\\b"
     name: "keyword.other.oracle"
   }
   {

--- a/grammars/pl sql (oracle).cson
+++ b/grammars/pl sql (oracle).cson
@@ -155,7 +155,7 @@ patterns: [
    name: "keyword.other.end.oracle"
   }
   {
-    match: "(?i)\\b(end|then|deterministic|exception|when|exists|others|subtype|constant|range|declare|begin|in|out|to|is|as|exit|raise|cursor|record|open|fetch|into|close|%type|%rowtype|execute|comment|column|synonym|sequence|index\\s+by|start\\s+with|increment\\s+by|cache|pragma|grant|start|alter|database|datafile|autoextend|trigger|after|before|each|row|default|\\.(extend|count|first|last|next|nextval|currval|reverse)|sqlerror|oserror|connect)\\b"
+    match: "(?i)\\b(end|then|deterministic|exception|when|exists|others|subtype|constant|range|declare|begin|in|out|to|is|as|exit|raise|cursor|record|open|fetch|into|close|%type|%rowtype|execute|comment|column|synonym|sequence|index\\s+by|start\\s+with|increment\\s+by|cache|pragma|grant|start|alter|database|datafile|autoextend|trigger|after|before|each|row|default|\\.(extend|count|first|last|next|nextval|currval|reverse)|sqlerror|oserror|connect|space)\\b"
     name: "keyword.other.oracle"
   }
   {

--- a/grammars/pl sql (oracle).cson
+++ b/grammars/pl sql (oracle).cson
@@ -155,11 +155,11 @@ patterns: [
    name: "keyword.other.end.oracle"
   }
   {
-    match: "(?i)\\b(end|then|deterministic|exception|when|exists|others|subtype|constant|range|declare|begin|in|out|to|is|as|exit|raise|cursor|record|open|fetch|into|close|%type|%rowtype|execute|comment|column|synonym|sequence|index\\s+by|start\\s+with|increment\\s+by|cache|pragma|grant|start|alter|database|datafile|autoextend|trigger|after|before|each|row|default|\\.(extend|count|first|last|next|nextval|currval|reverse)|sqlerror|oserror|connect|space)\\b"
+    match: "(?i)\\b(end|then|deterministic|exception|when|exists|others|subtype|constant|range|declare|begin|in|out|to|is|as|exit|raise|cursor|record|open|fetch|into|close|%type|%rowtype|execute|comment|column|synonym|sequence|index\\s+by|start\\s+with|increment\\s+by|cache|pragma|grant|start|alter|database|datafile|autoextend|trigger|after|before|each|row|default|\\.(extend|count|first|last|next|nextval|currval|reverse)|connect|space|cascade|shrink|partition|modify|enable|disable|add|validate|novalidate|including|compress|nocompress)\\b"
     name: "keyword.other.oracle"
   }
   {
-    match: "(?i)\\b(select|from|inner\\s+join|left\\s+join|left\\s+outer\\s+join|right\\s+join|right\\s+outer|join|full\\s+join|full\\s+outer\\s+join|on|off|where|order\\s+by|group\\s+by|asc|desc|update|set|all|insert|into|values|returning|delete|from|distinct|union|having|limit|table|of|drop|between|whenever)\\b"
+    match: "(?i)\\b(select|from|inner\\s+join|left\\s+join|left\\s+outer\\s+join|right\\s+join|right\\s+outer|join|full\\s+join|full\\s+outer\\s+join|on|off|where|order\\s+by|group\\s+by|asc|desc|update|set|all|insert|into|values|returning|delete|from|distinct|union|having|limit|table|tablespace|of|drop|between|whenever|sqlerror|oserror|index|indexes|with|pctfree|initrans|storage|initial|pctincrease|parallel|noparallel|by|maxvalue|nomaxvalue|nocache|pctused)\\b"
     name: "keyword.other.sql.oracle"
   }
   {
@@ -529,7 +529,7 @@ patterns: [
     name: "string.quoted.double.oracle"
   }
   {
-    match: "(?i)\\b(varchar2|nvarchar2|number|integer|float|long|date|binary_float|binary_double|timestamp|interval|raw|long\\s+raw|rowid|urowid|char|nchar|clob|nclob|blob|bfile|boolean|pls_integer|binary_integer|natural|naturaln|positive|positiven|signtype|simple_integer)\\b"
+    match: "(?i)\\b(varchar2|nvarchar2|number|integer|float|long|date|binary_float|binary_double|timestamp|interval|raw|long\\s+raw|rowid|urowid|char|nchar|clob|nclob|blob|bfile|boolean|pls_integer|binary_integer|natural|naturaln|positive|positiven|signtype|simple_integer|day|second|byte)\\b"
     name: "storage.type.oracle"
   }
   {

--- a/grammars/pl sql (oracle).cson
+++ b/grammars/pl sql (oracle).cson
@@ -155,11 +155,11 @@ patterns: [
    name: "keyword.other.end.oracle"
   }
   {
-    match: "(?i)\\b(end|then|deterministic|exception|when|exists|others|subtype|constant|range|declare|begin|in|out|to|is|as|exit|raise|cursor|record|open|fetch|into|close|%type|%rowtype|execute|comment|column|synonym|sequence|index\\s+by|start\\s+with|increment\\s+by|cache|pragma|grant|start|alter|database|datafile|autoextend|trigger|after|before|each|row|default|\\.(extend|count|first|last|next|nextval|currval|reverse)|connect|space|cascade|shrink|partition|modify|enable|disable|add|validate|novalidate|including|compress|nocompress)\\b"
+    match: "(?i)\\b(end|then|deterministic|exception|when|exists|others|subtype|constant|range|declare|begin|in|out|to|is|as|exit|raise|cursor|record|open|fetch|into|close|%type|%rowtype|execute|comment|column|synonym|sequence|index\\s+by|start\\s+with|increment\\s+by|cache|pragma|grant|start|alter|database|datafile|autoextend|trigger|after|before|each|row|default|\\.(extend|count|first|last|next|nextval|currval|reverse)|connect|space|cascade|shrink|partition|modify|enable|disable|add|validate|novalidate|including|compress|nocompress|define|accept|var|format|prompt|spool|authid|definer|current_user|object|self|result|at)\\b"
     name: "keyword.other.oracle"
   }
   {
-    match: "(?i)\\b(select|from|inner\\s+join|left\\s+join|left\\s+outer\\s+join|right\\s+join|right\\s+outer|join|full\\s+join|full\\s+outer\\s+join|on|off|where|order\\s+by|group\\s+by|asc|desc|update|set|all|insert|into|values|returning|delete|from|distinct|union|having|limit|table|tablespace|of|drop|between|whenever|sqlerror|oserror|index|indexes|with|pctfree|initrans|storage|initial|pctincrease|parallel|noparallel|by|maxvalue|nomaxvalue|nocache|pctused)\\b"
+    match: "(?i)\\b(select|from|inner\\s+join|left\\s+join|left\\s+outer\\s+join|right\\s+join|right\\s+outer|join|full\\s+join|full\\s+outer\\s+join|on|off|where|order\\s+by|group\\s+by|asc|desc|update|set|all|insert|into|values|returning|delete|from|distinct|union|having|limit|table|tablespace|of|drop|between|whenever|sqlerror|oserror|failure|success|warning|index|indexes|with|without|pctfree|initrans|storage|initial|pctincrease|parallel|noparallel|by|maxvalue|nomaxvalue|nocache|pctused|movement|attributes|split|exchange|validation|bitmap|list|hash|range|reference|organization|logging|nologging|store|securefile|basicfile|buffer_pool|flash_cache|cell_flash_cache|less\\s+than|lob|deferrable|local|global|initially|immediate|deferred)\\b"
     name: "keyword.other.sql.oracle"
   }
   {
@@ -529,7 +529,7 @@ patterns: [
     name: "string.quoted.double.oracle"
   }
   {
-    match: "(?i)\\b(varchar2|nvarchar2|number|integer|float|long|date|binary_float|binary_double|timestamp|interval|raw|long\\s+raw|rowid|urowid|char|nchar|clob|nclob|blob|bfile|boolean|pls_integer|binary_integer|natural|naturaln|positive|positiven|signtype|simple_integer|day|second|byte)\\b"
+    match: "(?i)\\b(varchar2|nvarchar2|number|integer|float|long|date|binary_float|binary_double|timestamp|interval|raw|long\\s+raw|rowid|urowid|char|nchar|clob|nclob|blob|bfile|boolean|pls_integer|binary_integer|natural|naturaln|positive|positiven|signtype|simple_integer|day|second|byte|nocopy)\\b"
     name: "storage.type.oracle"
   }
   {

--- a/grammars/pl sql (oracle).cson
+++ b/grammars/pl sql (oracle).cson
@@ -159,7 +159,7 @@ patterns: [
     name: "keyword.other.oracle"
   }
   {
-    match: "(?i)\\b(select|from|inner\\s+join|left\\s+join|left\\s+outer\\s+join|right\\s+join|right\\s+outer|join|full\\s+join|full\\s+outer\\s+join|on|off|where|order\\s+by|group\\s+by|asc|desc|update|set|all|insert|into|values|returning|delete|from|distinct|union|having|limit|table|of|drop|between)\\b"
+    match: "(?i)\\b(select|from|inner\\s+join|left\\s+join|left\\s+outer\\s+join|right\\s+join|right\\s+outer|join|full\\s+join|full\\s+outer\\s+join|on|off|where|order\\s+by|group\\s+by|asc|desc|update|set|all|insert|into|values|returning|delete|from|distinct|union|having|limit|table|of|drop|between|whenever)\\b"
     name: "keyword.other.sql.oracle"
   }
   {


### PR DESCRIPTION
See commentary on #31 

Unhandled in this PR:

- object name styling
- dual
- (sys.)anydata

![image](https://cloud.githubusercontent.com/assets/1747643/22085966/a6eb5400-de2a-11e6-986a-748522ac2fc8.png)
![image](https://cloud.githubusercontent.com/assets/1747643/22085988/b85e6fa6-de2a-11e6-9bc8-c418489e4e1c.png)

cc/ @kedvsk: if all looks good, I'll merge and release. Maybe you want to test before-hand (temporarily getting your ~/.atom/packages/language-oracle to point to this branch)?